### PR TITLE
[BUG] Check for empty response before JSON parsing

### DIFF
--- a/OriginateHTTP.podspec
+++ b/OriginateHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OriginateHTTP"
-  s.version          = "0.0.5"
+  s.version          = "0.0.6"
   s.summary          = "A lightweight HTTP networking client backed by NSURLSession."
 
   s.homepage         = "https://github.com/Originate/OriginateHTTP"

--- a/Pod/Classes/OriginateHTTPClient.m
+++ b/Pod/Classes/OriginateHTTPClient.m
@@ -194,8 +194,13 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
                 
                 if (HTTPResponse.statusCode >= 200 && HTTPResponse.statusCode <= 299) {
                     
-                    if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse] && data.length == 0) {
-                        responseBlock(nil, nil);
+                    if (data.length == 0) {
+                        if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse]) {
+                            responseBlock(nil, nil);
+                        }
+                        else {
+                            responseBlock(nil, [self errorEmptyResponse]);
+                        }
                         return;
                     }
                     
@@ -313,8 +318,13 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
                     return;
                 }
                 
-                if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse] && data.length == 0) {
-                    responseBlock(nil, nil);
+                if (data.length == 0) {
+                    if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse]) {
+                        responseBlock(nil, nil);
+                    }
+                    else {
+                        responseBlock(nil, [self errorEmptyResponse]);
+                    }
                     return;
                 }
                 
@@ -379,8 +389,13 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
                     return;
                 }
                 
-                if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse] && data.length == 0) {
-                    responseBlock(nil, nil);
+                if (data.length == 0) {
+                    if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse]) {
+                        responseBlock(nil, nil);
+                    }
+                    else {
+                        responseBlock(nil, [self errorEmptyResponse]);
+                    }
                     return;
                 }
                 
@@ -437,8 +452,13 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
                     return;
                 }
                 
-                if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse] && data.length == 0) {
-                    responseBlock(nil, nil);
+                if (data.length == 0) {
+                    if ([[self class] emptyBodyAcceptableForHTTPResponse:HTTPResponse]) {
+                        responseBlock(nil, nil);
+                    }
+                    else {
+                        responseBlock(nil, [self errorEmptyResponse]);
+                    }
                     return;
                 }
                 
@@ -518,6 +538,13 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
 + (NSString *)errorDomain
 {
     return @"com.originate.networking";
+}
+
++ (NSError *)errorEmptyResponse
+{
+    return [NSError errorWithDomain:[[self class] errorDomain]
+                               code:2
+                           userInfo:@{ NSLocalizedDescriptionKey : @"The response was empty." }];
 }
 
 + (NSError *)errorDecodingJSON

--- a/Pod/Classes/OriginateHTTPClient.m
+++ b/Pod/Classes/OriginateHTTPClient.m
@@ -543,7 +543,7 @@ NSString* const OriginateHTTPClientResponseNotification = @"com.originate.http-c
 + (NSError *)errorEmptyResponse
 {
     return [NSError errorWithDomain:[[self class] errorDomain]
-                               code:2
+                               code:3
                            userInfo:@{ NSLocalizedDescriptionKey : @"The response was empty." }];
 }
 


### PR DESCRIPTION
@pkluz @allewun 

This should avoid crashes when the server sends an empty response with certain headers.
